### PR TITLE
[#18] bug: 맥에서 쿼리 관련 버그 발견 및 수정

### DIFF
--- a/server/src/queries/goods.query.js
+++ b/server/src/queries/goods.query.js
@@ -124,12 +124,15 @@ const selectGoodsByWish = async (userId) => {
 
 const selectGoodsDetail = async (goodsId, userId) => {
   const [result] = await db.query(
-    `SELECT g.id, g.title, g.content, g.price, 
+    `SELECT distinct g.id, g.title, g.content, g.price, 
     g.thumbnail, g.view_count, g.view_state, 
     g.sale_state, g.user_id, g.region_id, g.category_id, 
     r.region as region_name, 
     DATE_FORMAT(g.updated,'%Y-%m-%d %H:%i:%S') as updated,
-    DATE_FORMAT(g.created,'%Y-%m-%d %H:%i:%S') as created, count(distinct w.id) as wish_count, CONCAT('[', GROUP_CONCAT(p.url), ']') AS urls, r.region, c.name as category, instr(g.user_id, '${userId}') as isAuthor, (SELECT count(w2.id) FROM goods_wish w2 WHERE w2.user_id = '${userId}') as isWish FROM goods g, goods_photo p, region r, category c, goods_wish w WHERE g.id = ${goodsId} AND g.view_state = 0 AND g.id = p.goods_id AND g.region_id = r.id AND g.category_id = c.id AND w.goods_id = g.id`,
+    DATE_FORMAT(g.created,'%Y-%m-%d %H:%i:%S') as created, (SELECT count(distinct w.id) FROM goods_wish w WHERE w.goods_id = g.id) as wish_count, r.region, c.name as category, instr(g.user_id, '${userId}') as isAuthor, (SELECT count(w2.id) FROM goods_wish w2 WHERE w2.user_id = '${userId}') as isWish FROM goods g, goods_photo p, region r, category c, goods_wish w WHERE g.id = ${goodsId} AND g.view_state = 0 AND g.id = p.goods_id AND g.region_id = r.id AND g.category_id = c.id`,
+  );
+  const [urlsRow] = await db.query(
+    `SELECT url FROM goods_photo WHERE goods_id = ${goodsId}`
   );
   if (result.length) {
     if (result[0].isAuthor !== 0) {
@@ -139,10 +142,11 @@ const selectGoodsDetail = async (goodsId, userId) => {
       result[0].view_count += 1;
       await db.query(
         `UPDATE goods SET view_count = view_count + 1 WHERE id = ${result[0].id}`,
-      );
-    }
+        );
+      }
     if (result[0].isWish) result[0].isWish = true;
     else result[0].isWish = false;
+    result[0].urls = urlsRow.map(row => row.url);
     return result[0];
   }
   return null;


### PR DESCRIPTION
- goods-wish의 로우가 없는 상태에서 where절의 id값 비교로 인해 empty set이 반환되는 문제였습니다.  